### PR TITLE
Javascript regex error in add-to-your-blog.php

### DIFF
--- a/add-to-your-blog.php
+++ b/add-to-your-blog.php
@@ -193,7 +193,7 @@
 			if($lEnableJavaScriptValidation){
 				echo "var lInvalidBlogPattern = /\'/;";
 			}else{
-				echo "var lInvalidBlogPattern = /*/;";
+				echo "var lInvalidBlogPattern = /[]/;";
 			}// end if
 		?>
 		


### PR DESCRIPTION
Found an apparently unintentional Javascript regex error in add-to-your-blog.php -- it looks like the intent was to create a regex that wouldn't match anything, but /*/ isn't valid. I suggest the substitution of /[]/, if the intent is for that section of code to work without error.