### PR TITLE
Update pen-test-tool-lookup-ajax.php

### DIFF
--- a/pen-test-tool-lookup-ajax.php
+++ b/pen-test-tool-lookup-ajax.php
@@ -109,7 +109,7 @@
 
 		try{ 
 			var lXMLHTTP;
-			var lURL = "/mutillidae/ajax/lookup-pen-test-tool.php";
+			var lURL = "./ajax/lookup-pen-test-tool.php";
 			var lRequestMethod = "POST";
 			var lAsyncronousRequestFlag = true;
 			


### PR DESCRIPTION
version 2.7.14 sorry i didnt see the stable release was 2.7.11
it search for an absolute or a relative path that doesnt exist 
`/mutillidae/ajax/lookup-pen-test-tool.php`

instead of 
`./ajax/lookup-pen-test-tool.php`

which is the real path to the file used 