### PR TITLE
Update conference-room-lookup.php

### DIFF
--- a/conference-room-lookup.php
+++ b/conference-room-lookup.php
@@ -11,7 +11,7 @@
 			if (ctype_alnum($pString[$i])){
 				$EncodedString.=$pString[$i];
 			}else{
-				$EncodedString.=$cBACKSLASH.strval(ord($pString[$i]));
+				$EncodedString.=$cBACKSLASH.strval(bin2hex($pString[$i]));
 			}
 		}
 		return $EncodedString;


### PR DESCRIPTION
The encodeForLDAP() function in the conference-room-lookup.php page was using the ord() function that returns the ASCII value as an integer, for LDAP encoding we need the hex value of the characters, hence the ord() function was replaced with bin2hex() which returns the hexadecimal value of the string.