### PR TITLE
bugfix: Initialize Encoder property in the Client Side Control Challenge

### DIFF
--- a/src/client-side-control-challenge.php
+++ b/src/client-side-control-challenge.php
@@ -44,7 +44,7 @@
 
 				//initialize encoder
 				require_once __SITE_ROOT__.'/classes/EncodingHandler.php';
-				$Encoder = new EncodingHandler();
+				$this->Encoder = new EncodingHandler();
 
 			} catch(Exception $e){
 				echo $CustomErrorHandler->FormatError($e, "ClientFields.__construct()");


### PR DESCRIPTION
Currently, the constructor of the client side control challenge creates a *local* Encoder variable, rather than setting the class's property.

This is breaking for security level 5, which uses HTML encoding for the output.

Setting the class's Encoder property instead fixes this.